### PR TITLE
Fix bbox string to query conversion

### DIFF
--- a/R/ppo_data.R
+++ b/R/ppo_data.R
@@ -163,8 +163,8 @@ make_queryURL <- function(params, limit = 100000L) {
         q,' ','termID',':"',value,'"', sep = "")
     else if (key == "bbox") {
       coord <- as.numeric(strsplit(value, ",")[[1]])
-      lats <- sort(coord[1:3])
-      lngs <- sort(coord[2:4])
+      lats <- sort(coord[c(1, 3)])
+      lngs <- sort(coord[c(2, 4)])
       q <- paste0(q,
                   " latitude:>=", lats[1],
                   " AND  latitude:<=", lats[2],


### PR DESCRIPTION
Fixes #16 

Tested with
```R
r2 <- ppo_data(bbox="37,-120,38,-119", limit=10,timeLimit = 4)
sending request for data ...
https://biscicol.org/api/v3/download/_search?q=+latitude:>=37+AND++latitude:<=38+AND++longitude:>=-120+AND++longitude:<=-119++AND+++source:USA-NPN&limit=10
> head(r2$data)
  dayOfYear year    genus    specificEpithet
1        54 1972 Lonicera korolkowii-zabelii
2       100 1971 Lonicera korolkowii-zabelii
3        92 1972 Lonicera korolkowii-zabelii
4       130 1973 Lonicera korolkowii-zabelii
5       108 1974 Lonicera korolkowii-zabelii
6       126 1980 Lonicera korolkowii-zabelii
                            eventRemarks latitude longitude
1 Full leaf (historic lilac/honeysuckle)    37.10   -119.48
````

The first point is within the bbox.