### PR TITLE
Remove hardcoded `source` and add as argument instead

### DIFF
--- a/R/ppo_data.R
+++ b/R/ppo_data.R
@@ -127,7 +127,7 @@ ppo_data <- function(
               Try specifying genus in scientificName if that's the case.")
     }
   }
-  params$source <- "USA-NPN"
+  # params$source <- "USA-NPN"
 
   queryURL <- make_queryURL(params = params, limit = limit)
 

--- a/R/ppo_data.R
+++ b/R/ppo_data.R
@@ -28,7 +28,9 @@
 #' @param timeLimit (integer) set the limit of the amount of time to wait for a response
 #' @param keepData (logical) whether to keep (TRUE) or delete (FALSE; default)
 #' the downloaded data (~/ppo_download/).
-#'
+#' @param source (character) return data from specified source. Options include
+#' ("PEP725", "IMAGE_SCORING", "HERBARIUM" and "USA-NPN"). Set to NULL to not
+#' apply this filter.
 #' @details
 #' The ppo_data function returns a list containing the following information:
 #' a readme file, citation information, a data frame with data, an integer with
@@ -84,7 +86,8 @@ ppo_data <- function(
     eventRemarks = NULL,
     limit = 100000L,
     timeLimit = 60,
-    keepData = FALSE) {
+    keepData = FALSE,
+    source = "USA-NPN") {
 
   # check arguments
   limit <- assert(limit, c("integer", "numeric", "character"))
@@ -105,6 +108,7 @@ ppo_data <- function(
     fromDay = assert(fromDay, c("integer", "numeric", "character")),
     toDay = assert(toDay, c("integer", "numeric", "character")),
     bbox = assert(bbox, "character"),
+    source = assert(source, "character"),
     subSource = assert(subSource, "character"),
     status = assert(status, "character"),
     eventRemarks = assert(eventRemarks, "character"),
@@ -127,7 +131,6 @@ ppo_data <- function(
               Try specifying genus in scientificName if that's the case.")
     }
   }
-  # params$source <- "USA-NPN"
 
   queryURL <- make_queryURL(params = params, limit = limit)
 

--- a/R/ppo_data.R
+++ b/R/ppo_data.R
@@ -219,7 +219,7 @@ process_response <- function(results, keepData = FALSE) {
     numPossible <- gsub("^.*possible = |\ntotal results returned.*$|,",
                         "\\1", readme)
     unlink(tf)
-    if (!keepData) unlink("ppo_download/", recursive = TRUE)
+    if (!keepData) unlink("~/ppo_download/", recursive = TRUE)
 
     list(
       "data" = ppo,

--- a/R/ppo_data.R
+++ b/R/ppo_data.R
@@ -17,6 +17,7 @@
 #' http://boundingbox.klokantech.com/ to quickly grab a bbox (set format on
 #' bottom left to csv and be sure to switch the order from
 #' long, lat, long, lat to lat, long, lat, long).
+#' @param source (character) return data from specified source. See details.
 #' @param subSource (character) return data from the specified sub-source.
 #' See details.
 #' @param status (character) Either "present" or "absent". Return data with the
@@ -28,16 +29,13 @@
 #' @param timeLimit (integer) set the limit of the amount of time to wait for a response
 #' @param keepData (logical) whether to keep (TRUE) or delete (FALSE; default)
 #' the downloaded data (~/ppo_download/).
-#' @param source (character) return data from specified source. Options include
-#' ("PEP725", "IMAGE_SCORING", "HERBARIUM" and "USA-NPN"). Set to NULL to not
-#' apply this filter.
 #' @details
 #' The ppo_data function returns a list containing the following information:
 #' a readme file, citation information, a data frame with data, an integer with
 #' the number of records returned and a status code. The function is called with
 #' parameters that correspond to values contained in the data itself which act
 #' as a filter on the returned record set. For a list of available mapped_traits,
-#' termID, subSource and subSource see the \code{\link{ppo_filters}} dataset. For mapped_traits and
+#' termID, Source and subSource see the \code{\link{ppo_filters}} dataset. For mapped_traits and
 #' termID, the \code{\link{ppo_get_terms}} function will return a data.frame with present,
 #' absent or both terms and traits information. The \code{\link{ppo_terms}} will
 #' do the same but will use the API to get the lastest data. However, some of
@@ -80,14 +78,14 @@ ppo_data <- function(
     fromDay = NULL,
     toDay = NULL,
     bbox = NULL,
+    source = NULL,
     subSource = NULL,
     status = NULL,
     mapped_traits = NULL,
     eventRemarks = NULL,
     limit = 100000L,
     timeLimit = 60,
-    keepData = FALSE,
-    source = "USA-NPN") {
+    keepData = FALSE) {
 
   # check arguments
   limit <- assert(limit, c("integer", "numeric", "character"))


### PR DESCRIPTION
This PR removes the hardcoded `source` argument as suggested in #18. Instead, it adds "source" as an additional argument. I'm not sure what you prefer for the default value of this keyword:

1. Default to "USA-NPN": this would mean the behaviour doesn't change, but it is quite inconsistent with the rest of the options. Users would manually have to set `source = NULL` to _not_ filter for any specific source
2. Default to NULL: more consistent with other keywords, more intuitive. But this changes the behaviour, such that calls to `ppo_data` that previously used to return only NPN data may now include data from other sources as well.

Currently, I picked option 2, which would be my personal preference. But I could change it back to option 1 if you think option 2 excessively impacts existing users.

This PR also fixes a typo in the `unlink` comment for the keepData option, which led to buggy behaviour as reported [here](https://github.com/phenology/springtime/issues/68).

closes #18