### PR TITLE
Fix CI

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Description: Search plant phenology data aggregated from several sources and ava
 Depends: R (>= 3.4.0)
 License: GPL-2
 Encoding: UTF-8
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.3
 Imports:
     jsonlite,
     readr,

--- a/R/ppo_data.R
+++ b/R/ppo_data.R
@@ -131,7 +131,6 @@ ppo_data <- function(
   }
 
   queryURL <- make_queryURL(params = params, limit = limit)
-
   results <- get_url(queryURL, timeLimit)
 
   process_response(results = results, keepData = keepData)
@@ -190,7 +189,7 @@ make_queryURL <- function(params, limit = 100000L) {
 }
 
 process_response <- function(results, keepData = FALSE) {
-  if (!length(results) && results$status_code != 200)
+  if (!length(results) || results$status_code != 200)
       list(
         "data" = NULL,
         "readme" = NULL,

--- a/R/ppo_data.R
+++ b/R/ppo_data.R
@@ -199,7 +199,7 @@ process_response <- function(results, keepData = FALSE) {
   else {
     tf <- tempfile()
 
-    # save file to disk
+    # Save file to disk
     writeBin(httr::content(results, "raw"), tf)
     unzip(tf, exdir = "~/ppo_download")
 

--- a/man/ppo_data.Rd
+++ b/man/ppo_data.Rd
@@ -14,6 +14,7 @@ ppo_data(
   fromDay = NULL,
   toDay = NULL,
   bbox = NULL,
+  source = NULL,
   subSource = NULL,
   status = NULL,
   mapped_traits = NULL,
@@ -46,6 +47,8 @@ See details.}
 http://boundingbox.klokantech.com/ to quickly grab a bbox (set format on
 bottom left to csv and be sure to switch the order from
 long, lat, long, lat to lat, long, lat, long).}
+
+\item{source}{(character) return data from specified source. See details.}
 
 \item{subSource}{(character) return data from the specified sub-source.
 See details.}
@@ -85,7 +88,7 @@ a readme file, citation information, a data frame with data, an integer with
 the number of records returned and a status code. The function is called with
 parameters that correspond to values contained in the data itself which act
 as a filter on the returned record set. For a list of available mapped_traits,
-termID, subSource and subSource see the \code{\link{ppo_filters}} dataset. For mapped_traits and
+termID, Source and subSource see the \code{\link{ppo_filters}} dataset. For mapped_traits and
 termID, the \code{\link{ppo_get_terms}} function will return a data.frame with present,
 absent or both terms and traits information. The \code{\link{ppo_terms}} will
 do the same but will use the API to get the lastest data. However, some of

--- a/man/ppo_filters.Rd
+++ b/man/ppo_filters.Rd
@@ -38,12 +38,6 @@ A list with 5 element:
       \item{ObjectProperty_termID2}{the term for a third object propriety in the definition; useful to filter for similar terms}
     }
   }
-  \item{genus}{A data set with 1 row and 2 variable:
-    \itemize{
-      \item{genus}{the genus name}
-      \item{nObs}{the number of obeservations}
-    }
-  }
   ...
 }
 }

--- a/man/ppo_terms.Rd
+++ b/man/ppo_terms.Rd
@@ -11,7 +11,7 @@ ppo_terms(present = FALSE, absent = FALSE, timeLimit = 4)
 
 \item{absent}{(boolean) IF TRUE then return all "absent" phenological stages.}
 
-\item{timeLimit}{(integer) set the limit ofthe amount of time to wait for a response}
+\item{timeLimit}{(integer) set the limit of the amount of time to wait for a response}
 }
 \value{
 data.frame


### PR DESCRIPTION
In #20 the CI turned red after merging. This PR attempts to fix it. 

- Fixes an omission in #20: update documentation
- Fixes an older issue where the code would still attempt to parse the result if a 204 was returned. Somehow it seems this causes warnings instead of errors for some of the runs (e.g. https://github.com/ropensci/rppo/actions/runs/4313873785/jobs/7526208777)

Similar to #19, I tested on our own fork and the CI curiously failed for just one of the matrix members. Let's see what happens here