### PR TITLE
Don't short-circuit in checking return code

### DIFF
--- a/R/ppo_data.R
+++ b/R/ppo_data.R
@@ -189,7 +189,7 @@ make_queryURL <- function(params, limit = 100000L) {
 }
 
 process_response <- function(results, keepData = FALSE) {
-  if (!length(results) || results$status_code != 200)
+  if (!length(results) | results$status_code != 200)
       list(
         "data" = NULL,
         "readme" = NULL,

--- a/R/ppo_data.R
+++ b/R/ppo_data.R
@@ -189,7 +189,7 @@ make_queryURL <- function(params, limit = 100000L) {
 }
 
 process_response <- function(results, keepData = FALSE) {
-  if (!length(results) | results$status_code != 200)
+  if (!length(results) | (length(results) && results$status_code != 200))
       list(
         "data" = NULL,
         "readme" = NULL,

--- a/R/ppo_traits.R
+++ b/R/ppo_traits.R
@@ -26,7 +26,7 @@ ppo_traits <- function(x, sorted = TRUE, flatten_traits = TRUE, flatten_all = FA
   out <- lapply(gsub("^.*/([0-9]*)$", "\\1", x$data$eventId[1:2]), function(id){
     x <- jsonlite::read_json(
       paste0(
-        "http://www.usanpn.org/npn_portal/observations/getObservationById.json?request_src=PPO&observation_id=",
+        "http://services.usanpn.org/npn_portal/observations/getObservationById.json?request_src=PPO&observation_id=",
         id), simplifyVector = T
     )
     if (sorted)

--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ started with rppo. We recommend visiting the [rppo
 vignette](https://htmlpreview.github.io/?https://github.com/ropensci/rppo/blob/master/vignettes/rppo-vignette.html)
 for a more complete set of examples on using the rppo package, as well
 as viewing man pages for rppo functions in the R environment, using
-`?ppo_data` and
-`?ppo_terms`.
+`?ppo_data` and `?ppo_terms`.
 
 ``` r
 # query all results from day 1 through 100 in a particular bounding box, 


### PR DESCRIPTION
I noticed that when I made a query that warned me about "no results found", the response was still filled with data from a previous query. 

This is because, in checking the result, the first condition was true and the short-circuit evaluation thus proceeded with the else branch without checking the second condition.

Instead, it should return empty when
- no result
- yes result, but the status code is wrong

Also updates the URL to NPN servers